### PR TITLE
Add Decidim::TermCustomizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "decidim-conferences", DECIDIM_VERSION
 gem 'decidim-members', git: "https://github.com/CodiTramuntana/decidim-members.git", tag: "v0.1.14"
 gem 'decidim-verifications-csv_email', git: "https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git", tag: "v0.0.6"
 gem 'decidim-file_authorization_handler', git: "https://github.com/MarsBased/decidim-file_authorization_handler.git"
+gem "decidim-term_customizer"
 
 gem 'delayed_job_active_record'
 gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,9 @@ GEM
       jquery-rails (~> 4.3)
       sassc (~> 1.12, >= 1.12.1)
       sassc-rails (~> 1.3)
+    decidim-term_customizer (0.17.1)
+      decidim-admin (~> 0.17.0)
+      decidim-core (~> 0.17.0)
     decidim-verifications (0.17.0)
       decidim-core (= 0.17.0)
     declarative-builder (0.1.0)
@@ -818,6 +821,7 @@ DEPENDENCIES
   decidim-initiatives (~> 0.17.0)
   decidim-members!
   decidim-sortitions (~> 0.17.0)
+  decidim-term_customizer
   decidim-verifications-csv_email!
   delayed_job_active_record
   faker (~> 1.9.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,9 @@ module CoditMultitenantApp
 
     config.active_job.queue_adapter = :delayed_job
 
+    # Default app time zone
+    config.time_zone = 'Madrid'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/db/migrate/20190520161827_create_decidim_term_customizer_translation_sets.decidim_term_customizer.rb
+++ b/db/migrate/20190520161827_create_decidim_term_customizer_translation_sets.decidim_term_customizer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132503)
+
+class CreateDecidimTermCustomizerTranslationSets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_translation_sets do |t|
+      t.jsonb :name
+    end
+  end
+end

--- a/db/migrate/20190520161828_create_decidim_term_customizer_translations.decidim_term_customizer.rb
+++ b/db/migrate/20190520161828_create_decidim_term_customizer_translations.decidim_term_customizer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132654)
+
+class CreateDecidimTermCustomizerTranslations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_translations do |t|
+      t.string :locale
+      t.string :key
+      t.text :value
+
+      t.references(
+        :translation_set,
+        null: false,
+        foreign_key: { to_table: :decidim_term_customizer_translation_sets },
+        index: { name: "decidim_term_customizer_translation_translation_set" }
+      )
+    end
+  end
+end

--- a/db/migrate/20190520161829_create_decidim_term_customizer_constraints.decidim_term_customizer.rb
+++ b/db/migrate/20190520161829_create_decidim_term_customizer_constraints.decidim_term_customizer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132726)
+
+class CreateDecidimTermCustomizerConstraints < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_constraints do |t|
+      t.references :decidim_organization, null: false, foreign_key: true, index: { name: "decidim_term_customizer_constraint_organization" }
+      t.references :subject, polymorphic: true, index: { name: "decidim_term_customizer_constraint_subject" }
+
+      t.references(
+        :translation_set,
+        null: false,
+        foreign_key: { to_table: :decidim_term_customizer_translation_sets },
+        index: { name: "decidim_term_customizer_constraint_translation_set" }
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_155354) do
+ActiveRecord::Schema.define(version: 2019_05_20_161829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1470,6 +1470,28 @@ ActiveRecord::Schema.define(version: 2019_05_07_155354) do
     t.index ["reset_password_token"], name: "index_decidim_system_admins_on_reset_password_token", unique: true
   end
 
+  create_table "decidim_term_customizer_constraints", force: :cascade do |t|
+    t.bigint "decidim_organization_id", null: false
+    t.string "subject_type"
+    t.bigint "subject_id"
+    t.bigint "translation_set_id", null: false
+    t.index ["decidim_organization_id"], name: "decidim_term_customizer_constraint_organization"
+    t.index ["subject_type", "subject_id"], name: "decidim_term_customizer_constraint_subject"
+    t.index ["translation_set_id"], name: "decidim_term_customizer_constraint_translation_set"
+  end
+
+  create_table "decidim_term_customizer_translation_sets", force: :cascade do |t|
+    t.jsonb "name"
+  end
+
+  create_table "decidim_term_customizer_translations", force: :cascade do |t|
+    t.string "locale"
+    t.string "key"
+    t.text "value"
+    t.bigint "translation_set_id", null: false
+    t.index ["translation_set_id"], name: "decidim_term_customizer_translation_translation_set"
+  end
+
   create_table "decidim_user_group_memberships", id: :serial, force: :cascade do |t|
     t.integer "decidim_user_id", null: false
     t.integer "decidim_user_group_id", null: false
@@ -1646,6 +1668,9 @@ ActiveRecord::Schema.define(version: 2019_05_07_155354) do
   add_foreign_key "decidim_scopes", "decidim_scope_types", column: "scope_type_id"
   add_foreign_key "decidim_scopes", "decidim_scopes", column: "parent_id"
   add_foreign_key "decidim_static_pages", "decidim_organizations"
+  add_foreign_key "decidim_term_customizer_constraints", "decidim_organizations"
+  add_foreign_key "decidim_term_customizer_constraints", "decidim_term_customizer_translation_sets", column: "translation_set_id"
+  add_foreign_key "decidim_term_customizer_translations", "decidim_term_customizer_translation_sets", column: "translation_set_id"
   add_foreign_key "decidim_users", "decidim_organizations"
   add_foreign_key "decidim_verifications_csv_data", "decidim_organizations"
   add_foreign_key "decidim_verifications_csv_email_csv_email_data", "decidim_organizations"


### PR DESCRIPTION
> Sant Boi volen utilitzar el mòdul d’assemblees pels Consells de Barri. La seva proposta inicial és fer el canvi del títol **Assemblees** a **Òrgans**.
> Es proposa que des de l’Administrador es pugui editar aquest títol per part dels tècnics de l’Ajuntament amb total autonomia, sense la necessitat d’un desenvolupament informàtic cada vegada que es vulgui realitzar aquesta edició.

Objectiu aconseguit gràcies a [Decidim::TermCustomizer](https://github.com/mainio/decidim-module-term_customizer).

S'adjunta un zip amb un JSON que s'haurà d'importar des del backoffice, al menú **Personalització de Termes**, per aplicar els canvis demanats per les traduccions d'assemblees: [set-translations-24-05-2019-52919.zip](https://github.com/CodiTramuntana/decidim-codit_multitenant-app/files/3217167/set-translations-24-05-2019-52919.zip)

#### Notes 
Followed the gem instruccions:
- Update Gemfile
```
gem "decidim-term_customizer"
```
- Execute
```
$ bundle
$ bundle exec rails decidim_term_customizer:install:migrations
$ bundle exec rails db:migrate
```
#### Also
Added default app `time_zone`.