### PR TITLE
Force ransack gem version to fix undefined method 'polymorphic?'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,11 @@ gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 4.0.0'
 gem 'figaro', '>= 1.1.1'
 
+# Force gem version to fix:
+# undefined method `polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection
+# See: https://github.com/activerecord-hackery/ransack/issues/1039
+gem 'ransack', '2.1.1'
+
 group :development, :test do
   gem 'faker', '~> 1.9.1'
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,8 +608,6 @@ GEM
     pg_search (2.1.7)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
-    polyamorous (2.3.0)
-      activerecord (>= 5.0)
     powerpack (0.1.2)
     premailer (1.11.1)
       addressable
@@ -659,12 +657,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    ransack (2.3.0)
+    ransack (2.1.1)
       actionpack (>= 5.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       i18n
-      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -858,6 +855,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   puma (~> 3.0)
+  ransack (= 2.1.1)
   sanitize (~> 4.0, >= 4.0.1)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
Force ransack gem version to fix:
`undefined method 'polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection`

See: https://github.com/activerecord-hackery/ransack/issues/1039