### PR TITLE
[UPGRADE] decidim 19 bugfix backport and term_customizer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-conferences", DECIDIM_VERSION
 gem 'decidim-members', git: "https://github.com/CodiTramuntana/decidim-members.git", tag: "v0.1.16"
 gem 'decidim-verifications-csv_email', git: "https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git", tag: "v0.0.7"
 gem 'decidim-file_authorization_handler', git: "https://github.com/MarsBased/decidim-file_authorization_handler.git"
-gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git"
+gem "decidim-term_customizer", git: 'https://github.com/mainio/decidim-module-term_customizer'
 gem 'decidim-verifications-sant_boi_census', git: "https://github.com/CodiTramuntana/decidim-verifications-sant_boi_census.git", tag: "v0.0.2"
 
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GIT
 
 GIT
   remote: https://github.com/decidim/decidim.git
-  revision: 5cad11696ce2215042933ba5c59b5bf7d4038ddf
+  revision: b8ef312335fbda056d37ba41f04f1df91fc68a2d
   branch: 0.19-stable
   specs:
     decidim (0.19.0)
@@ -445,7 +445,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.6)
       i18n (>= 0.7)
-    faraday (0.17.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     figaro (1.1.1)
@@ -493,7 +493,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    icalendar (2.5.3)
+    icalendar (2.6.0)
       ice_cube (~> 0.16)
     ice_cube (0.16.3)
     ice_nine (0.11.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       pg_search (>= 2.1.4)
 
 GIT
-  remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
-  revision: 407e43d52bfc5c1e6e585ed04cc65c235ff26881
-  specs:
-    decidim-term_customizer (0.17.2)
-      decidim-admin (>= 0.17.0)
-      decidim-core (>= 0.17.0)
-
-GIT
   remote: https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git
   revision: e2768d5e35d07990b1ee03a3fcf8bb83c1b53542
   tag: v0.0.7
@@ -257,6 +249,14 @@ GIT
       sassc-rails (~> 1.3)
     decidim-verifications (0.19.0)
       decidim-core (= 0.19.0)
+
+GIT
+  remote: https://github.com/mainio/decidim-module-term_customizer
+  revision: a0055f708cfe82571c6d4b1291d07cad432baf67
+  specs:
+    decidim-term_customizer (0.19.0)
+      decidim-admin (~> 0.19.0)
+      decidim-core (~> 0.19.0)
 
 GEM
   remote: https://rubygems.org/
@@ -601,7 +601,7 @@ GEM
     paper_trail (10.3.1)
       activerecord (>= 4.2)
       request_store (~> 1.1)
-    parallel (1.19.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
@@ -620,8 +620,8 @@ GEM
     rack (2.0.7)
     rack-attack (6.2.1)
       rack (>= 1.0, < 3)
-    rack-cors (1.0.6)
-      rack (>= 1.6.0)
+    rack-cors (1.1.0)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -723,7 +723,7 @@ GEM
     rubocop-rails (2.0.1)
       rack (>= 1.1)
       rubocop (>= 0.70.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
@@ -782,7 +782,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tomlrb (1.2.8)
+    tomlrb (1.2.9)
     truncato (0.7.11)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.7.0, <= 2.0)


### PR DESCRIPTION
Related to https://github.com/CodiTramuntana/decidim-codit_multitenant-app/pull/26
- Updated decidim gem to get latest bugfix
- Changed term_customizer dependency to main repository