### PR TITLE
Do not fix ransack version anymore, bug was resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,6 @@ gem 'puma', '~> 4.3'
 gem 'uglifier', '>= 4.0.0'
 gem 'figaro', '>= 1.1.1'
 
-# Force gem version to fix:
-# undefined method `polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection
-# See: https://github.com/activerecord-hackery/ransack/issues/1039
-gem 'ransack', '2.1.1'
-
 group :development, :test do
   gem 'faker', '~> 1.9.1'
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,7 +592,7 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.7)
     nobspw (0.6.2)
-    nokogiri (1.11.6)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -899,7 +899,6 @@ DEPENDENCIES
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   puma (~> 4.3)
-  ransack (= 2.1.1)
   sanitize (~> 5.2)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
The bug has already been resolved: https://github.com/activerecord-hackery/ransack/pull/1122

No need to stay with v2.1.1