### PR TITLE
Remove ssl option in mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,8 +92,7 @@ Rails.application.configure do
     password: Rails.application.secrets.smtp_password,
     domain: Rails.application.secrets.smtp_domain,
     enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
-    openssl_verify_mode: "none",
-    ssl: true
+    openssl_verify_mode: "none"
   }
 
   if Rails.application.secrets.sendgrid


### PR DESCRIPTION
The `ssl` smtp option was not accepted by Sendgrid anymore.