### PR TITLE
Configure Rack Attack throttling

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -16,6 +16,12 @@ Decidim.configure do |config|
     api_key: Rails.application.secrets.maps[:here_api_key],
     static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
   }
+
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  config.throttling_max_requests = Rails.application.secrets.decidim[:throttling_max_requests].to_i
+
+  # Time window in which the throttling is applied.
+  config.throttling_period = Rails.application.secrets.decidim[:throttling_period].to_i.minutes
 end
 
 # Inform Decidim about the assets folder

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,7 +10,13 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+decidim_default: &decidim_default
+  throttling_max_requests: <%= ENV["DECIDIM_THROTTLING_MAX_REQUESTS"].to_i %>
+  throttling_period: <%= ENV["DECIDIM_THROTTLING_PERIOD"].to_i %>
+
 default: &default
+  decidim:
+    <<: *decidim_default
   omniauth:
     facebook:
       # It must be a boolean. Remember ENV variables doesn't support booleans.


### PR DESCRIPTION
Decidim's default Throttling is too small. This PR allows to change the throttling via environment variables avoiding having to rebuild.