### PR TITLE
Add matrix gem for delayed_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,10 @@ gem "webpacker"
 
 # if deploying to a dedicated server
 gem "daemons"
+
 gem "delayed_job_active_record"
+gem "matrix", "~> 0.4.2"
+
 gem "whenever"
 # elsif deploying to a PaaS like Heroku
 # gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -934,6 +934,7 @@ DEPENDENCIES
   figaro (>= 1.1.1)
   letter_opener_web
   listen
+  matrix (~> 0.4.2)
   openssl
   psych (< 4)
   puma


### PR DESCRIPTION
Error:

```
codit@decidim-codit-multitenant-app:~/multitenant-app/current$ bin/delayed_job start
/var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require': No such file to load -- matrix.rb (LoadError)
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/origami-2.1.0/lib/origami/graphics/state.rb:21:in `<top (required)>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/origami-2.1.0/lib/origami/graphics.rb:32:in `<top (required)>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/origami-2.1.0/lib/origami/pdf.rb:38:in `<top (required)>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/origami-2.1.0/lib/origami.rb:41:in `<top (required)>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/bundler/gems/decidim-2a1624acf3ac/decidim-initiatives/app/services/decidim/initiatives/pdf_signature_example.rb:3:in `<top (required)>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `block in require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:332:in `require'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:424:in `block in require_or_load'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:39:in `block in load_interlock'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies/interlock.rb:13:in `loading'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:39:in `load_interlock'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:402:in `require_or_load'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:375:in `depend_on'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/activesupport-6.1.7.3/lib/active_support/dependencies.rb:288:in `require_dependency'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:493:in `block (2 levels) in eager_load!'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:492:in `each'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:492:in `block in eager_load!'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:489:in `each'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:489:in `eager_load!'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/engine.rb:358:in `eager_load!'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/application/finisher.rb:134:in `each'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/application/finisher.rb:134:in `block in <module:Finisher>'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/initializable.rb:32:in `instance_exec'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/initializable.rb:32:in `run'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:228:in `block in tsort_each'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:347:in `each'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:347:in `call'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:347:in `each_strongly_connected_component'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:226:in `tsort_each'
	from /home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/tsort.rb:205:in `tsort_each'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/initializable.rb:60:in `run_initializers'
	from /var/www/coditramuntana/decidim/multitenant-app/shared/bundle/ruby/3.1.0/gems/railties-6.1.7.3/lib/rails/application.rb:391:in `initialize!'
	from /var/www/coditramuntana/decidim/multitenant-app/releases/20230614065111/config/environment.rb:7:in `<top (required)>'
	from <internal:/home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/home/codit/.rbenv/versions/3.1.3/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from bin/delayed_job:4:in `<main>'
```

Solution: https://stackoverflow.com/a/72031582/7290770
