### PR TITLE
Lock ChromeDriver to 119.0.6045.105

### DIFF
--- a/.github/workflows/ci_app.yml
+++ b/.github/workflows/ci_app.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
+
       - run: npm install
 
       - name: Recover Ruby dependency cache


### PR DESCRIPTION
We must lock the chromedriver version because test fails. There was a PR in Decidim about that --> https://github.com/decidim/decidim/pull/12159

![image](https://github.com/CodiTramuntana/decidim-codit_multitenant-app/assets/75725233/9c0b8851-9264-4d0f-b56b-cd6d9c26f1c5)
