### PR TITLE
Add missing FileAuthorizationHandler migration

### DIFF
--- a/.github/workflows/ci_app.yml
+++ b/.github/workflows/ci_app.yml
@@ -39,20 +39,17 @@ jobs:
       SECRET_KEY_BASE: "secret_key_base"
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      - uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: 119.0.6045.105
 
       - run: npm install
 
@@ -72,7 +69,7 @@ jobs:
           chrome-version: 119.0.6045.105
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-app-rubydeps-${{ hashFiles('Gemfile.lock') }}
@@ -81,7 +78,7 @@ jobs:
             ${{ runner.OS }}-app-rubydeps-
 
       - name: Install Ruby deps
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -94,7 +91,7 @@ jobs:
           RAILS_ENV=test bundle exec rails db:migrate
 
       - name: Run RSpec
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -25,7 +25,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-rubydeps-${{ hashFiles('Gemfile.lock') }}
@@ -38,7 +38,7 @@ jobs:
         run: bundle config set --local path 'vendor/bundle'
 
       - name: Install Ruby deps
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/validate_migrations.yml
+++ b/.github/workflows/validate_migrations.yml
@@ -1,0 +1,52 @@
+name: "[CI] Validate migrations"
+
+on:
+  push:
+    branches:
+      - master
+      - release/*
+      - "*-stable"
+  pull_request:
+
+env:
+  DB_DATABASE: app
+  DB_USERNAME: postgres
+  DB_PASSWORD: postgres
+  RUBY_VERSION: 3.1.3
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_KEY_BASE: "secret_key_base"
+
+    steps:
+      - uses: actions/checkout@v2.0.0
+        with:
+          fetch-depth: 1
+      - uses: ruby/setup-ruby@master
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - name: Recover Ruby dependency cache
+        uses: actions/cache@v1
+        with:
+          path: ./vendor/bundle
+          key: ${{ runner.OS }}-app-rubydeps-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-app-rubydeps-${{ env.cache-name }}-
+            ${{ runner.OS }}-app-rubydeps-
+
+      - name: Set bundle local config vendor/bundle path
+        run: bundle config set --local path 'vendor/bundle'
+
+      - name: Install Ruby deps
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: bundle install --jobs 4 --retry 3
+
+      - name: Run specs
+        run: bin/rails cdtb:upgrades:validate_migrations

--- a/.github/workflows/validate_migrations.yml
+++ b/.github/workflows/validate_migrations.yml
@@ -17,11 +17,26 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_PASSWORD: postgres
     env:
+      DB_DATABASE: app
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: localhost
       SECRET_KEY_BASE: "secret_key_base"
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: ruby/setup-ruby@master
@@ -29,7 +44,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-app-rubydeps-${{ hashFiles('Gemfile.lock') }}
@@ -41,7 +56,7 @@ jobs:
         run: bundle config set --local path 'vendor/bundle'
 
       - name: Install Ruby deps
-        uses: nick-invision/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/db/migrate/20250522082740_add_extras_to_census_datum.decidim_file_authorization_handler.rb
+++ b/db/migrate/20250522082740_add_extras_to_census_datum.decidim_file_authorization_handler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_file_authorization_handler (originally 20221207143742)
+
+class AddExtrasToCensusDatum < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_file_authorization_handler_census_data, :extras, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_27_092953) do
+ActiveRecord::Schema.define(version: 2025_05_22_082740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
   enable_extension "unaccent"
+
   create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -776,6 +779,7 @@ ActiveRecord::Schema.define(version: 2023_04_27_092953) do
     t.string "id_document"
     t.date "birthdate"
     t.datetime "created_at", null: false
+    t.jsonb "extras"
     t.index ["decidim_organization_id"], name: "decidim_census_data_org_id_index"
   end
 


### PR DESCRIPTION
For some reason the `add_extras_to_census_datum` migration from the FileAuthorizationHandler was missing.

- This PR adds it.
- Also adds the `decidim-cdtb` "Validate migrations" GitHub Action test.
- Update versions for GitHub actions.
